### PR TITLE
More semantic default selectors

### DIFF
--- a/INPUT_SCHEMA.json
+++ b/INPUT_SCHEMA.json
@@ -16,14 +16,14 @@
             "type": "string",
             "description": "CSS selector of an area you want to monitor",
             "editor": "textfield",
-            "prefill": ".jfTIjc p:nth-of-type(1)"
+            "prefill": "[class^=change-log__MonthBox-]:nth-of-type(1) ul"
         },
         "screenshotSelector": {
             "title": "Screenshot selector",
             "type": "string",
             "description": "CSS selector of a screenshot you want to get",
             "editor": "textfield",
-            "prefill": ".jfTIjc p:nth-of-type(1)"
+            "prefill": "[class^=change-log__MonthBox-]:nth-of-type(1) ul"
         },
         "sendNotificationTo": {
             "title": "Email address",


### PR DESCRIPTION
Hi again @metalwarrior665 :))

While exploring and running various actors, I've noticed that the example selector matches just the first line of the changelog instead of whole `ul`, as it was probably originally intended https://github.com/apify/actor-content-checker/commit/17e5fca800a57c22e2bb4b0675bbdbc97a2bcf16

**Current**

![image](https://user-images.githubusercontent.com/697301/97407415-ee124f00-18fa-11eb-9c14-32c4fb1d1cd2.png)

**Updated**

![image](https://user-images.githubusercontent.com/697301/97407442-f66a8a00-18fa-11eb-9e62-7ed8bf4223d3.png)


